### PR TITLE
Discussion archive

### DIFF
--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -4,13 +4,13 @@ class DiscussionsController < ApplicationController
   def index
     @discussions = case params[:category]
     when "conversation"
-      @course.discussions.conversations
+      @course.discussions.active.conversations
     when "review"
-      @course.discussions.reviews
+      @course.discussions.active.reviews
     when "evaluation"
-      @course.discussions.evaluations
+      @course.discussions.active.evaluations
     else
-      @course.discussions.conversations
+      @course.discussions.active.conversations
     end
   end
 

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -2,33 +2,8 @@ class DiscussionsController < ApplicationController
   before_filter :find_course
 
   def index
-    if params[:state] == "closed"
-      @discussions = case params[:category]
-      when "conversation"
-        @course.discussions.inactive.conversations
-      when "review"
-        @course.discussions.inactive.reviews
-      when "evaluation"
-        @course.discussions.inactive.evaluations
-      else
-        @course.discussions.inactive.conversations
-      end
-
-      @discussions = DiscussionListDecorator.new(@discussions)
-    else
-      @discussions = case params[:category]
-      when "conversation"
-        @course.discussions.active.conversations
-      when "review"
-        @course.discussions.active.reviews
-      when "evaluation"
-        @course.discussions.active.evaluations
-      else
-        @course.discussions.active.conversations
-      end
-    end
-
-    @discussions = DiscussionListDecorator.new(@discussions)
+    matches      = Discussion.search(params)
+    @discussions = DiscussionListDecorator.new(matches)
   end
 
   private

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -13,6 +13,8 @@ class DiscussionsController < ApplicationController
       else
         @course.discussions.inactive.conversations
       end
+
+      @discussions = DiscussionListDecorator.new(@discussions)
     else
       @discussions = case params[:category]
       when "conversation"
@@ -25,6 +27,8 @@ class DiscussionsController < ApplicationController
         @course.discussions.active.conversations
       end
     end
+
+    @discussions = DiscussionListDecorator.new(@discussions)
   end
 
   private

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -2,15 +2,28 @@ class DiscussionsController < ApplicationController
   before_filter :find_course
 
   def index
-    @discussions = case params[:category]
-    when "conversation"
-      @course.discussions.active.conversations
-    when "review"
-      @course.discussions.active.reviews
-    when "evaluation"
-      @course.discussions.active.evaluations
+    if params[:state] == "closed"
+      @discussions = case params[:category]
+      when "conversation"
+        @course.discussions.inactive.conversations
+      when "review"
+        @course.discussions.inactive.reviews
+      when "evaluation"
+        @course.discussions.inactive.evaluations
+      else
+        @course.discussions.inactive.conversations
+      end
     else
-      @course.discussions.active.conversations
+      @discussions = case params[:category]
+      when "conversation"
+        @course.discussions.active.conversations
+      when "review"
+        @course.discussions.active.reviews
+      when "evaluation"
+        @course.discussions.active.evaluations
+      else
+        @course.discussions.active.conversations
+      end
     end
   end
 

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -1,0 +1,50 @@
+class DiscussionListDecorator < ApplicationDecorator
+  decorates :discussion
+
+  def category_filters
+    [conversations_link, reviews_link, evaluations_link].join(" | ").html_safe
+  end
+
+  def state_filters
+    output = if h.params[:state] == "closed"
+      link_params = h.params.merge(:state => "open")
+
+      "State: " +
+      h.link_to("Open", h.course_discussions_path(link_params)) +
+      " | Closed"
+    else
+      link_params = h.params.merge(:state => "closed")
+
+      "State: Open | " +
+      h.link_to("Closed", h.course_discussions_path(link_params))
+    end
+
+    output.html_safe
+  end
+
+  def matched_discussions
+    all.map do |discussion| 
+      h.content_tag(:h3, discussion.subject)
+    end.join.html_safe
+  end
+
+  private
+
+  def conversations_link
+    link_params = h.params.merge(:category => "conversation")
+
+    h.link_to "Conversations", h.course_discussions_path(link_params)
+  end
+
+  def reviews_link
+    link_params = h.params.merge(:category => "review")
+
+    h.link_to "Reviews", h.course_discussions_path(link_params)
+  end
+
+  def evaluations_link
+    link_params = h.params.merge(:category => "evaluation")
+
+    h.link_to "Evaluations", h.course_discussions_path(link_params)
+  end
+end

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -31,19 +31,19 @@ class DiscussionListDecorator < ApplicationDecorator
   private
 
   def conversations_link
-    link_params = h.params.merge(:category => "conversation")
+    link_params = h.params.merge(:category => "conversations")
 
     h.link_to "Conversations", h.course_discussions_path(link_params)
   end
 
   def reviews_link
-    link_params = h.params.merge(:category => "review")
+    link_params = h.params.merge(:category => "reviews")
 
     h.link_to "Reviews", h.course_discussions_path(link_params)
   end
 
   def evaluations_link
-    link_params = h.params.merge(:category => "evaluation")
+    link_params = h.params.merge(:category => "evaluations")
 
     h.link_to "Evaluations", h.course_discussions_path(link_params)
   end

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -30,30 +30,26 @@ class DiscussionListDecorator < ApplicationDecorator
 
   private
 
-  def conversations_link    
-    if h.params[:category] == "conversations" || h.params[:category].blank?
-      "Conversations"
+  def discussions_link(category_name)
+    if h.params[:category] == category_name
+      category_name.capitalize
     else
-      link_params = h.params.merge(:category => "conversations")
-      h.link_to "Conversations", h.course_discussions_path(link_params)
+      link_params = h.params.merge(:category => category_name)
+      h.link_to category_name.capitalize, h.course_discussions_path(link_params)
     end
+  end
+
+  def conversations_link    
+    return "Conversations" if h.params[:category].blank?
+
+    discussions_link("conversations")
   end
 
   def reviews_link
-    if h.params[:category] == "reviews"
-      "Reviews"
-    else
-      link_params = h.params.merge(:category => "reviews")
-      h.link_to "Reviews", h.course_discussions_path(link_params)
-    end
+    discussions_link("reviews")
   end
 
   def evaluations_link
-    if h.params[:category] == "evaluations"
-      "Evaluations"
-    else
-      link_params = h.params.merge(:category => "evaluations")
-      h.link_to "Evaluations", h.course_discussions_path(link_params)
-    end
+   discussions_link("evaluations")
   end
 end

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -30,21 +30,30 @@ class DiscussionListDecorator < ApplicationDecorator
 
   private
 
-  def conversations_link
-    link_params = h.params.merge(:category => "conversations")
-
-    h.link_to "Conversations", h.course_discussions_path(link_params)
+  def conversations_link    
+    if h.params[:category] == "conversations" || h.params[:category].blank?
+      "Conversations"
+    else
+      link_params = h.params.merge(:category => "conversations")
+      h.link_to "Conversations", h.course_discussions_path(link_params)
+    end
   end
 
   def reviews_link
-    link_params = h.params.merge(:category => "reviews")
-
-    h.link_to "Reviews", h.course_discussions_path(link_params)
+    if h.params[:category] == "reviews"
+      "Reviews"
+    else
+      link_params = h.params.merge(:category => "reviews")
+      h.link_to "Reviews", h.course_discussions_path(link_params)
+    end
   end
 
   def evaluations_link
-    link_params = h.params.merge(:category => "evaluations")
-
-    h.link_to "Evaluations", h.course_discussions_path(link_params)
+    if h.params[:category] == "evaluations"
+      "Evaluations"
+    else
+      link_params = h.params.merge(:category => "evaluations")
+      h.link_to "Evaluations", h.course_discussions_path(link_params)
+    end
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,6 +1,20 @@
-class Discussion < ActiveRecord::Base
-  belongs_to :course
+class Discussion < ActiveRecord::Base  
+  VALID_CATEGORIES = ["conversations", "reviews", "evaluations"]
 
+  belongs_to :course
+  
+  def self.search(params)
+    results = params["state"] =="closed" ? inactive : active
+    
+    category = params["category"]
+    
+    if VALID_CATEGORIES.include?(category)
+      results.send(category)
+    else
+      results.conversations 
+    end
+  end
+  
   def self.active
     where(:archived => false)
   end
@@ -10,14 +24,14 @@ class Discussion < ActiveRecord::Base
   end
   
   def self.conversations
-    where(:category => "conversation")
+    where(:category => "conversations")
   end
 
   def self.reviews
-    where(:category => "review")
+    where(:category => "reviews")
   end
 
   def self.evaluations
-    where(:category => "evaluation")
+    where(:category => "evaluations")
   end
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,6 +1,14 @@
 class Discussion < ActiveRecord::Base
   belongs_to :course
 
+  def self.active
+    where(:archived => false)
+  end
+  
+  def self.inactive
+    where(:archived => true)
+  end
+  
   def self.conversations
     where(:category => "conversation")
   end

--- a/app/views/discussions/index.html.haml
+++ b/app/views/discussions/index.html.haml
@@ -1,28 +1,11 @@
-= link_to "Conversations", 
-  course_discussions_path(params.merge(:category => "conversation"))
-|
-= link_to "Reviews", 
-  course_discussions_path(params.merge(:category => "review"))
-|
-= link_to "Evaluations", 
-  course_discussions_path(params.merge(:category => "evaluation"))
+= @discussions.category_filters 
 
 %br
 %br
 
-  - if params[:state] == "closed"
-    State: 
-    = link_to "Open", course_discussions_path(params.merge(:state => "open"))
-    |
-    Closed
-  -else
-    State: 
-    Open 
-    |
-    = link_to  "Closed", course_discussions_path(params.merge(:state => "closed"))
+= @discussions.state_filters
 
 %br
 %br
 
-- @discussions.each do |discussion|
-  %h3= discussion.subject
+= @discussions.matched_discussions

--- a/app/views/discussions/index.html.haml
+++ b/app/views/discussions/index.html.haml
@@ -1,8 +1,25 @@
-= link_to "Conversations", course_discussions_path(:category => "conversation")
+= link_to "Conversations", 
+  course_discussions_path(params.merge(:category => "conversation"))
 |
-= link_to "Reviews", course_discussions_path(:category => "review")
+= link_to "Reviews", 
+  course_discussions_path(params.merge(:category => "review"))
 |
-= link_to "Evaluations", course_discussions_path(:category => "evaluation")
+= link_to "Evaluations", 
+  course_discussions_path(params.merge(:category => "evaluation"))
+
+%br
+%br
+
+  - if params[:state] == "closed"
+    State: 
+    = link_to "Open", course_discussions_path(params.merge(:state => "open"))
+    |
+    Closed
+  -else
+    State: 
+    Open 
+    |
+    = link_to  "Closed", course_discussions_path(params.merge(:state => "closed"))
 
 %br
 %br

--- a/db/migrate/20120317200349_add_archived_field_to_discussion.rb
+++ b/db/migrate/20120317200349_add_archived_field_to_discussion.rb
@@ -1,0 +1,5 @@
+class AddArchivedFieldToDiscussion < ActiveRecord::Migration
+  def change
+    add_column :discussions, :archived, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120316053737) do
+ActiveRecord::Schema.define(:version => 20120317200349) do
 
   create_table "course_memberships", :force => true do |t|
     t.integer  "course_id"
@@ -33,8 +33,9 @@ ActiveRecord::Schema.define(:version => 20120316053737) do
     t.text     "subject"
     t.text     "body"
     t.integer  "course_id"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
+    t.datetime "created_at",                    :null => false
+    t.datetime "updated_at",                    :null => false
+    t.boolean  "archived",   :default => false
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -18,7 +18,7 @@ conversations = [ "How awesome is Jordan Byron?",
 
 conversations.each do |e|
   course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "conversation"
+    :subject => e, :category => "conversations"
   )
 end
 
@@ -28,7 +28,7 @@ evaluations =  [ "My s10-e2 is ready for evaluation",
 
 evaluations.each do |e|
   course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "evaluation"
+    :subject => e, :category => "evaluations"
   )
 end
 
@@ -38,6 +38,6 @@ reviews = ["Messy first spike on my individual project",
 
 reviews.each do |e|
   course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "review"
+    :subject => e, :category => "reviews"
   )
 end


### PR DESCRIPTION
We've added basic support for filtering archived discussions and did a bunch of refactoring in the process of doing so.

We made some small changes to the way categories are labeled (pluralized them), so if anyone has run the seeds we created, you'll need to either manually pluralize your discussion categories or run `Discussion.destroy_all` on the console then run rake db:seed again.

Also, we didn't add archived discussions to the seed data yet, because the seed data is messy enough as it is, and will be obsolete once we actually have an archive button in place. To simulate some archived discussions, it's easy to run `Discussion.all.sample.update_attribute(:archived, true)` a few times.

But if you want to be lazy and not actually _run_ this code, you can just watch this short video: http://www.youtube.com/watch?v=xCpLvmG_2dc (watch at 720p for best results) 
