### PR TITLE
.rvmrc & task to add liskov upstream

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,1 @@
+rvm ruby-1.9.3-p0@liskov --create

--- a/lib/tasks/setup.rake
+++ b/lib/tasks/setup.rake
@@ -72,6 +72,15 @@ task :setup do
     Rake::Task["db:seed"].invoke
   end
 
+  section "Add mendicant-university/liskov as upstream" do
+    upstream_exists = `git remote | grep upstream`
+    if upstream_exists.empty?
+      sh %{ git remote add upstream git@github.com:mendicant-university/liskov.git } do |ok, res|
+        puts "Unable to add main liskov repo as upstream: Status => #{res.exitstatus}" if !ok
+      end
+    end
+  end
+
   puts # Empty Line
   puts "==== Setup Complete ====".color(:green)
   puts # Empty Line


### PR DESCRIPTION
I added a .rvmrc file that specified ruby version as 1.9.3 & creates a liskov gemset if one does not already exist. This may not be ideal if folks don't use RVM or if we don't want to use 1.9.3. In that case, you can cherry pick the other commit that adds mendicant-university/liskov as upstream. It's nice to have the upstream to be able to pull new code from so I thought it fit right in the setup tasks.
