### PR TITLE
Course Task CRUD

### DIFF
--- a/test/functional/tasks_controller_test.rb
+++ b/test/functional/tasks_controller_test.rb
@@ -1,28 +1,27 @@
 require "test_helper"
 
-class TasksControllerTest < ActionController::TestCase
-
-  def setup
+describe TasksController do
+  before do
     @course = FactoryGirl.create(:webdev)
     @controller.current_person = build_person(:instructor, @course)
   end
 
-  test "#new is not allowed to students" do
+  it "#new is not allowed to students" do
     @controller.current_person = build_person(:student)
 
     get(:new, course_id: @course.id)
-    assert_redirected_to(@course)
-    assert flash[:alert]
+    response.redirect?.must_equal true
+    flash[:alert].must_equal "Unauthorized access"
   end
 
-  test "#new is allowed to instructors" do
+  it "#new is allowed to instructors" do
     get(:new, course_id: @course.id)
-    assert_template "new"
+    response.success?.must_equal true
   end
 
-  test "redirects to root if can't find course" do
+  it "redirects to root if can't find course" do
     get(:new, course_id: 'ohai!')
-    assert_redirected_to(root_url)
-    assert flash[:alert]
+    response.redirect?.must_equal true
+    flash[:alert].must_equal "Couldn't find course"
   end
 end

--- a/test/integration/tasks_test.rb
+++ b/test/integration/tasks_test.rb
@@ -1,26 +1,27 @@
 require "test_helper"
 
-class TasksTest < ActionDispatch::IntegrationTest
-  def setup
+describe "Tasks Integration" do
+
+  before do
     @course     = FactoryGirl.create(:webdev)
     @instructor = build_person(:instructor, @course)
     @student    = build_person(:student, @course)
   end
 
-  test "an instructor can create a new course task" do
+  it "an instructor can create a new course task" do
     sign_in(@instructor)
 
     click_link "Web Development"
     click_link "Add Task"
     fill_in("Description", with: "Community Service")
     click_button "Create Task"
-    assert_includes(page.body, "Community Service")
+    page.body.must_include("Community Service")
   end
 
-  test "a student can only view course tasks" do
+  it "a student can only view course tasks" do
     sign_in(@student)
 
     click_link "Web Development"
-    assert_not_includes(page.body, "Add Task")
+    page.body.wont_include("Add Task")
   end
 end

--- a/test/support/integration.rb
+++ b/test/support/integration.rb
@@ -1,0 +1,34 @@
+module Support
+  module Integration
+    def sign_in(person)
+      visit root_url(host: "test.host")
+      fill_in("Name", with: person.name)
+      fill_in("Email", with: person.email)
+      fill_in("Nickname", with: person.github_nickname)
+      click_button "Sign In"
+      page.body.must_include("Welcome to Liskov")
+    end
+  end
+
+  class IntegrationSpec < MiniTest::Spec
+    include Rails.application.routes.url_helpers
+    include Capybara::DSL
+    include Integration
+
+    after { Capybara.reset_sessions! }
+  end
+
+  class ControllerSpec < MiniTest::Spec
+    include Rails.application.routes.url_helpers
+    include ActiveSupport::Testing::SetupAndTeardown
+
+    alias :method_name :__name__ if defined? :__name__
+
+    include ActionController::TestCase::Behavior
+
+    before { @routes = Rails.application.routes }
+  end
+end
+
+MiniTest::Spec.register_spec_type(/Integration$/, Support::IntegrationSpec)
+MiniTest::Spec.register_spec_type(/Controller$/, Support::ControllerSpec)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,26 +2,11 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require "capybara/rails"
+require "minitest/spec"
+require "support/integration"
 
 Clubhouse::Client.test_mode = true
 
 def build_person(person, course = nil)
   PersonDecorator.new(FactoryGirl.build(person, course: course))
-end
-
-class ActiveSupport::TestCase
-end
-
-class ActionDispatch::IntegrationTest
-  include Capybara::DSL
-  teardown { Capybara.reset_sessions! }
-
-  def sign_in(person)
-    visit root_url
-    fill_in("Name", with: person.name)
-    fill_in("Email", with: person.email)
-    fill_in("Nickname", with: person.github_nickname)
-    click_button "Sign In"
-    assert_includes(page.body, "Welcome to Liskov")
-  end
 end


### PR DESCRIPTION
@wicz and I have built the ability to add Tasks for Courses. Only instructors in a course may add tasks. This provides the foundation for the tasks that will appear (and be editable by instructors) on the student page.
