### PR TITLE
Discussions CRUD + Listing

### DIFF
--- a/app/assets/stylesheets/application.css.sass
+++ b/app/assets/stylesheets/application.css.sass
@@ -1,3 +1,4 @@
 //= require_self
 
 @import partials/base
+@import partials/discussions

--- a/app/assets/stylesheets/partials/_discussions.sass
+++ b/app/assets/stylesheets/partials/_discussions.sass
@@ -1,0 +1,6 @@
+img.discussion_list
+  float: left
+  padding-right: 10px
+
+h3.discussion_list
+  padding-top: 5px

--- a/app/assets/stylesheets/partials/_discussions.sass
+++ b/app/assets/stylesheets/partials/_discussions.sass
@@ -1,15 +1,18 @@
-img.discussion_list
+img.discussions
   float: left
   padding-right: 10px
 
-h3.discussion_list
+h3.discussions
   padding-top: 5px
   margin-bottom: 10px
   
-p.discussion_list.date
+p.discussions.date
   float: right
   padding-top: 10px
   margin-bottom: 10px
   
-a.discussion_list.new
+a.discussions.new
   float: right
+  
+a.discussions.show
+  text-decoration: none

--- a/app/assets/stylesheets/partials/_discussions.sass
+++ b/app/assets/stylesheets/partials/_discussions.sass
@@ -4,3 +4,9 @@ img.discussion_list
 
 h3.discussion_list
   padding-top: 5px
+  margin-bottom: 10px
+  
+p.discussion_list.date
+  float: right
+  padding-top: 10px
+  margin-bottom: 10px

--- a/app/assets/stylesheets/partials/_discussions.sass
+++ b/app/assets/stylesheets/partials/_discussions.sass
@@ -10,3 +10,6 @@ p.discussion_list.date
   float: right
   padding-top: 10px
   margin-bottom: 10px
+  
+a.discussion_list.new
+  float: right

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -7,6 +7,19 @@ class DiscussionsController < ApplicationController
   end
 
   def new
+    @discussion = Discussion.new
+    @category   = params[:category]
+  end
+  
+  def create
+    discussion_params = params[:discussion].
+                        merge(:author => current_person.github_nickname)
+                        
+    discussion = Discussion.create(discussion_params)
+    redirect_to course_discussion_path(params[:course_id], discussion)
+  end
+  
+  def show
     raise NotImplementedError
   end
   

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -2,7 +2,7 @@ class DiscussionsController < ApplicationController
   before_filter :find_course
 
   def index
-    matches      = Discussion.search(params)
+    matches      = @course.discussions.search(params)
     @discussions = DiscussionListDecorator.new(matches)
   end
 
@@ -11,16 +11,29 @@ class DiscussionsController < ApplicationController
     @category   = params[:category]
   end
   
+  def edit
+    raise NotImplementedError
+  end
+  
   def create
     discussion_params = params[:discussion].
-                        merge(:author => current_person.github_nickname)
+                        merge(:author    => current_person.github_nickname,
+                              :course_id => @course.id)
                         
     discussion = Discussion.create(discussion_params)
     redirect_to course_discussion_path(params[:course_id], discussion)
   end
   
   def show
-    raise NotImplementedError
+    @discussion = DiscussionDecorator.find(params[:id])
+  end
+  
+  # TODO: Seperate this into an admin feature which really destroys,
+  # and an archive route. Also, provide a way to re-open the discussions.
+  def destroy
+    Discussion.find(params[:id]).update_attribute(:archived, true)
+    
+    redirect_to course_discussions_path
   end
   
   private

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -6,6 +6,10 @@ class DiscussionsController < ApplicationController
     @discussions = DiscussionListDecorator.new(matches)
   end
 
+  def new
+    raise NotImplementedError
+  end
+  
   private
   
   def find_course

--- a/app/decorators/discussion_decorator.rb
+++ b/app/decorators/discussion_decorator.rb
@@ -16,6 +16,9 @@ class DiscussionDecorator < ApplicationDecorator
     h.content_tag(:h2, discussion.subject)
   end
   
+  def body
+    discussion.body.to_s.html_safe
+  end
   
   # TODO: Support unarchive
   def footer

--- a/app/decorators/discussion_decorator.rb
+++ b/app/decorators/discussion_decorator.rb
@@ -1,0 +1,8 @@
+class DiscussionDecorator < ApplicationDecorator
+  decorates :discussion
+  allows :subject
+  
+  def author
+    PersonDecorator.from_github_name(discussion.author)
+  end
+end

--- a/app/decorators/discussion_decorator.rb
+++ b/app/decorators/discussion_decorator.rb
@@ -5,4 +5,8 @@ class DiscussionDecorator < ApplicationDecorator
   def author
     PersonDecorator.from_github_name(discussion.author)
   end
+  
+  def start_date
+    discussion.created_at.strftime("%Y-%m-%d")
+  end
 end

--- a/app/decorators/discussion_decorator.rb
+++ b/app/decorators/discussion_decorator.rb
@@ -1,6 +1,6 @@
 class DiscussionDecorator < ApplicationDecorator
   decorates :discussion
-  allows :subject
+  allows :subject, :body
   
   def author
     PersonDecorator.from_github_name(discussion.author)
@@ -8,5 +8,23 @@ class DiscussionDecorator < ApplicationDecorator
   
   def start_date
     discussion.created_at.strftime("%Y-%m-%d")
+  end
+  
+  def header
+    h.content_tag(:p, start_date, :class => ["discussions","date"]) +
+    h.image_tag(author.gravatar_url(30), :class => "discussions") +
+    h.content_tag(:h2, discussion.subject)
+  end
+  
+  
+  # TODO: Support unarchive
+  def footer
+    link_params = [h.params["course_id"], h.params["id"]]
+    [ h.link_to("Edit", h.edit_course_discussion_path(*link_params)), 
+      h.link_to_if(!discussion.archived, "Archive", 
+                h.course_discussion_path(*link_params), 
+                :method => :delete, :confirm => "Are you sure?") { "Unarchive" },
+      h.link_to("Back to #{discussion.category}", h.course_discussions_path(:category => discussion.category))
+     ].join(" | ").html_safe
   end
 end

--- a/app/decorators/discussion_decorator.rb
+++ b/app/decorators/discussion_decorator.rb
@@ -12,22 +12,40 @@ class DiscussionDecorator < ApplicationDecorator
   
   def header
     h.content_tag(:p, start_date, :class => ["discussions","date"]) +
-    h.image_tag(author.gravatar_url(30), :class => "discussions") +
+    h.image_tag(author.gravatar_url(30), :class => "discussions")   +
     h.content_tag(:h2, discussion.subject)
   end
   
   def body
     discussion.body.to_s.html_safe
   end
+
+  def state
+    discussion.archived ? "closed" : "open"
+  end
   
   # TODO: Support unarchive
   def footer
-    link_params = [h.params["course_id"], h.params["id"]]
-    [ h.link_to("Edit", h.edit_course_discussion_path(*link_params)), 
-      h.link_to_if(!discussion.archived, "Archive", 
-                h.course_discussion_path(*link_params), 
-                :method => :delete, :confirm => "Are you sure?") { "Unarchive" },
-      h.link_to("Back to #{discussion.category}", h.course_discussions_path(:category => discussion.category))
-     ].join(" | ").html_safe
+    [ edit_link, archive_link, discussion_list_link ].join(" | ").html_safe
+  end
+
+  private
+
+  def edit_link
+    path = h.edit_course_discussion_path(discussion.course.id, discussion.id)
+
+    h.link_to("Edit", path)
+  end
+
+  def archive_link
+    h.link_to_if(!discussion.archived, "Archive", 
+      h.course_discussion_path(discussion.course.id, discussion.id), 
+      :method => :delete, :confirm => "Are you sure?") { "Unarchive" }
+  end
+
+  def discussion_list_link
+    h.link_to("Back to #{discussion.category}", 
+      h.course_discussions_path(:category => discussion.category, 
+                                :state    => state))
   end
 end

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -31,11 +31,21 @@ class DiscussionListDecorator < ApplicationDecorator
       h.content_tag(:hr)
     end.join.html_safe
   end
+  
+  def new_discussion_link
+    h.link_to("New Discussion", 
+      h.new_course_discussion_path(:category => category), 
+      :class => ["discussion_list","new"])
+  end
+  
+  def category
+    h.params[:category] || "conversations"
+  end
 
   private
 
   def discussions_link(category_name)
-    if h.params[:category] == category_name
+    if category == category_name
       category_name.capitalize
     else
       link_params = h.params.merge(:category => category_name)
@@ -44,8 +54,6 @@ class DiscussionListDecorator < ApplicationDecorator
   end
 
   def conversations_link    
-    return "Conversations" if h.params[:category].blank?
-
     discussions_link("conversations")
   end
 

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -26,7 +26,9 @@ class DiscussionListDecorator < ApplicationDecorator
     discussion_list.all.map do |discussion|
       discussion = DiscussionDecorator.new(discussion)
       h.image_tag(discussion.author.gravatar_url(30), :class => "discussion_list") +
-      h.content_tag(:h3, discussion.subject, :class => "discussion_list")
+      h.content_tag(:p, discussion.start_date, :class => ["discussion_list","date"]) +
+      h.content_tag(:h3, discussion.subject, :class => "discussion_list") +
+      h.content_tag(:hr)
     end.join.html_safe
   end
 

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -1,5 +1,5 @@
 class DiscussionListDecorator < ApplicationDecorator
-  decorates :discussion_list, :class => Discussion
+  decorates :discussions, :class => Discussion
 
   def category_filters
     [conversations_link, reviews_link, evaluations_link].join(" | ").html_safe
@@ -23,11 +23,15 @@ class DiscussionListDecorator < ApplicationDecorator
   end
 
   def matched_discussions
-    discussion_list.all.map do |discussion|
+    discussions.all.map do |discussion|
+      course     = discussion.course
       discussion = DiscussionDecorator.new(discussion)
-      h.image_tag(discussion.author.gravatar_url(30), :class => "discussion_list") +
-      h.content_tag(:p, discussion.start_date, :class => ["discussion_list","date"]) +
-      h.content_tag(:h3, discussion.subject, :class => "discussion_list") +
+      h.image_tag(discussion.author.gravatar_url(30), :class => "discussions") +
+      h.content_tag(:p, discussion.start_date, :class => ["discussions","date"]) +
+      h.link_to(
+        h.content_tag(:h3, discussion.subject, :class => "discussions"),
+        h.course_discussion_path(course, discussion), 
+          :class => ["discussions","show"]) +
       h.content_tag(:hr)
     end.join.html_safe
   end
@@ -35,7 +39,7 @@ class DiscussionListDecorator < ApplicationDecorator
   def new_discussion_link
     h.link_to("New Discussion", 
       h.new_course_discussion_path(:category => category), 
-      :class => ["discussion_list","new"])
+      :class => ["discussions","new"])
   end
   
   def category

--- a/app/decorators/discussion_list_decorator.rb
+++ b/app/decorators/discussion_list_decorator.rb
@@ -1,5 +1,5 @@
 class DiscussionListDecorator < ApplicationDecorator
-  decorates :discussion
+  decorates :discussion_list, :class => Discussion
 
   def category_filters
     [conversations_link, reviews_link, evaluations_link].join(" | ").html_safe
@@ -23,8 +23,10 @@ class DiscussionListDecorator < ApplicationDecorator
   end
 
   def matched_discussions
-    all.map do |discussion| 
-      h.content_tag(:h3, discussion.subject)
+    discussion_list.all.map do |discussion|
+      discussion = DiscussionDecorator.new(discussion)
+      h.image_tag(discussion.author.gravatar_url(30), :class => "discussion_list") +
+      h.content_tag(:h3, discussion.subject, :class => "discussion_list")
     end.join.html_safe
   end
 

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -34,4 +34,5 @@ class Discussion < ActiveRecord::Base
   def self.evaluations
     where(:category => "evaluations")
   end
+
 end

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -1,6 +1,7 @@
 class Discussion < ActiveRecord::Base  
   VALID_CATEGORIES = ["conversations", "reviews", "evaluations"]
 
+  validates_presence_of :category
   belongs_to :course
   
   def self.search(params)
@@ -34,5 +35,4 @@ class Discussion < ActiveRecord::Base
   def self.evaluations
     where(:category => "evaluations")
   end
-
 end

--- a/app/views/discussions/_form.html.haml
+++ b/app/views/discussions/_form.html.haml
@@ -1,0 +1,14 @@
+= form_for(@discussion, :url => url) do |f|
+  %p
+    - if @discussion.new_record?
+      = f.hidden_field :category, :value => @category
+      
+    = f.label       :subject
+    %br
+    = f.text_field  :subject, :value => @discussion.subject
+  %p
+    = f.label       :body
+    %br
+    = f.text_area   :body, :value => @discussion.body
+  
+  = f.submit

--- a/app/views/discussions/edit.html.haml
+++ b/app/views/discussions/edit.html.haml
@@ -1,0 +1,4 @@
+%h2 Edit your discussion
+
+= render :partial => "form",  
+          :locals => { :url => course_discussion_path(@course.id, @discussion) }

--- a/app/views/discussions/index.html.haml
+++ b/app/views/discussions/index.html.haml
@@ -3,6 +3,8 @@
 %br
 %br
 
+= link_to "New Discussion", new_course_discussion_path, 
+          :class => ["discussion_list","new"]
 = @discussions.state_filters
 
 %br

--- a/app/views/discussions/index.html.haml
+++ b/app/views/discussions/index.html.haml
@@ -3,8 +3,7 @@
 %br
 %br
 
-= link_to "New Discussion", new_course_discussion_path, 
-          :class => ["discussion_list","new"]
+= @discussions.new_discussion_link
 = @discussions.state_filters
 
 %br

--- a/app/views/discussions/new.html.haml
+++ b/app/views/discussions/new.html.haml
@@ -1,15 +1,3 @@
 %h2 Create a new discussion
 
-= form_for @discussion, :url => course_discussions_path do |f|
-  = f.hidden_field :category, :value => @category
-  %p
-    = f.label       :subject
-    %br
-    = f.text_field  :subject
-  %p
-    = f.label       :body
-    %br
-    = f.text_area   :body
-  
-  = f.submit
-  
+= render :partial => "form",  :locals => { :url => course_discussions_path }

--- a/app/views/discussions/new.html.haml
+++ b/app/views/discussions/new.html.haml
@@ -1,0 +1,15 @@
+%h2 Create a new discussion
+
+= form_for @discussion, :url => course_discussions_path do |f|
+  = f.hidden_field :category, :value => @category
+  %p
+    = f.label       :subject
+    %br
+    = f.text_field  :subject
+  %p
+    = f.label       :body
+    %br
+    = f.text_area   :body
+  
+  = f.submit
+  

--- a/app/views/discussions/show.html.haml
+++ b/app/views/discussions/show.html.haml
@@ -1,0 +1,4 @@
+= @discussion.header
+= @discussion.body
+%hr
+= @discussion.footer

--- a/db/migrate/20120325235236_add_author_field_to_discussion.rb
+++ b/db/migrate/20120325235236_add_author_field_to_discussion.rb
@@ -1,0 +1,5 @@
+class AddAuthorFieldToDiscussion < ActiveRecord::Migration
+  def change
+    add_column :discussions, :author, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120317200349) do
+ActiveRecord::Schema.define(:version => 20120325235236) do
 
   create_table "course_memberships", :force => true do |t|
     t.integer  "course_id"
@@ -36,6 +36,7 @@ ActiveRecord::Schema.define(:version => 20120317200349) do
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
     t.boolean  "archived",   :default => false
+    t.string   "author"
   end
 
   create_table "tasks", :force => true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,33 +11,3 @@ people = [frank, barbora]
 people.each do |person|
   person.create(course_id: course.id, role: "Student") if person.empty?
 end
-
-conversations = [ "How awesome is Jordan Byron?",
-                  "How many unicorns does it take to make a rainbow?",
-                  "Can someone ask a serious question please?" ]
-
-conversations.each do |e|
-  course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "conversations"
-  )
-end
-
-evaluations =  [ "My s10-e2 is ready for evaluation",
-                 "Revisions have been made to my s10-e1",
-                 "Come on, evaluate it, you know you want to!" ]
-
-evaluations.each do |e|
-  course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "evaluations"
-  )
-end
-
-reviews = ["Messy first spike on my individual project",
-          "Proof of concept patch to add archives to Newman",
-          "If you don't review this soon, I might go crazy!"]
-
-reviews.each do |e|
-  course.discussions.find_or_create_by_subject(
-    :subject => e, :category => "reviews"
-  )
-end


### PR DESCRIPTION
Hi Jordan, we aren't ready to merge upstream yet, but I wanted to do an interim review request just so that we can learn a few things and roll in some of your suggestions before we do merge.

Jia and I have worked on making it so discussions can be associated with an author. To do this, we ended up having to do a bit of [gravatar integration](https://github.com/mendicant-university/liskov/commit/b55c42d6b7df79996a03f197dcc2c0392bed9f3a) and [refactoring of PersonDecorator](https://github.com/mendicant-university/liskov/commit/b55c42d6b7df79996a03f197dcc2c0392bed9f3a), but we made those changes on master because they seemed to be generally useful.

After making those changes, we updated the code on our feature branch to implement authorship and gravatars, as shown by the screenshot below.

![](http://i.imgur.com/O234g.png)

I left [a few questions for you on one of our commits](https://github.com/sandal/liskov/commit/0c02f4b5c073d93d1f3f1c1dc6af0757a7647329), but would be happy to hear any other feedback you have as well.

NOTE: In order to run this code it is necessary to update any discussions from our original seed data using something like:

``` ruby
Discussion.all.each { |a| a.update_attribute(:author, "sandal") }
```

We plan to add very simple discussion CRUD before merging, and delete the db/seeds.rb file. But I figured I'd let you know about this gotcha in the interim.
